### PR TITLE
Fix history msg bug

### DIFF
--- a/src/utils/paseLink.js
+++ b/src/utils/paseLink.js
@@ -1,0 +1,20 @@
+const paseLink = (msg) => {
+    var reg =
+        /(https?\:\/\/|www\.)([a-zA-Z0-9-]+(\.[a-zA-Z0-9]+)+)(\:[0-9]{2,4})?\/?((\.[:_0-9a-zA-Z-]+)|[:_0-9a-zA-Z-]*\/?)*\??[:_#@*&%0-9a-zA-Z-/=]*/gm
+
+    msg = msg.replace(reg, function (v) {
+        var prefix = /^https?/gm.test(v)
+
+        return (
+            "<a href='" +
+            (prefix ? v : '//' + v) +
+            "' target='_blank'>" +
+            v +
+            '</a>'
+        )
+    })
+
+    return msg
+}
+
+export default paseLink

--- a/src/utils/paseLink.js
+++ b/src/utils/paseLink.js
@@ -1,10 +1,11 @@
 const paseLink = (msg) => {
+    let isLink = false
     var reg =
         /(https?\:\/\/|www\.)([a-zA-Z0-9-]+(\.[a-zA-Z0-9]+)+)(\:[0-9]{2,4})?\/?((\.[:_0-9a-zA-Z-]+)|[:_0-9a-zA-Z-]*\/?)*\??[:_#@*&%0-9a-zA-Z-/=]*/gm
 
     msg = msg.replace(reg, function (v) {
-        var prefix = /^https?/gm.test(v)
-
+        const prefix = /^https?/gm.test(v)
+        isLink = prefix
         return (
             "<a href='" +
             (prefix ? v : '//' + v) +
@@ -14,7 +15,7 @@ const paseLink = (msg) => {
         )
     })
 
-    return msg
+    return { isLink, msg }
 }
 
 export default paseLink

--- a/src/views/Chat/components/Message/components/messageList.vue
+++ b/src/views/Chat/components/Message/components/messageList.vue
@@ -41,6 +41,12 @@ const isMyself = computed(() => {
         return msgBody.from === loginUserId
     }
 })
+/* 文本中是否包含link */
+const isLink = computed(() => {
+    return (msg) => {
+        return paseLink(msg).isLink
+    }
+})
 /* 获取自己的用户信息 */
 const loginUserInfo = computed(() => store.state.loginUserInfo)
 
@@ -190,13 +196,12 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                         style="padding: 10px; line-height: 20px"
                         v-if="msgBody.type === ALL_MESSAGE_TYPE.TEXT"
                     >
-                        <span v-show="!paseLink(msgBody.msg).isLink">
+                        <template v-if="!isLink(msgBody.msg)">
                             {{ msgBody.msg }}
-                        </span>
-                        <span
-                            v-show="paseLink(msgBody.msg).isLink"
-                            v-html="paseLink(msgBody.msg).msg"
-                        ></span>
+                        </template>
+                        <template v-else>
+                            <span v-html="paseLink(msgBody.msg).msg"> </span
+                        ></template>
                     </p>
                     <!-- 图片类型消息 -->
                     <!-- <div> -->

--- a/src/views/Chat/components/Message/components/messageList.vue
+++ b/src/views/Chat/components/Message/components/messageList.vue
@@ -189,8 +189,15 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                     <p
                         style="padding: 10px; line-height: 20px"
                         v-if="msgBody.type === ALL_MESSAGE_TYPE.TEXT"
-                        v-html="paseLink(msgBody.msg)"
-                    ></p>
+                    >
+                        <span v-show="!paseLink(msgBody.msg).isLink">
+                            {{ msgBody.msg }}
+                        </span>
+                        <span
+                            v-show="paseLink(msgBody.msg).isLink"
+                            v-html="paseLink(msgBody.msg).msg"
+                        ></span>
+                    </p>
                     <!-- 图片类型消息 -->
                     <!-- <div> -->
                     <el-image

--- a/src/views/Chat/components/Message/components/messageList.vue
+++ b/src/views/Chat/components/Message/components/messageList.vue
@@ -75,13 +75,13 @@ const handleMsgTimeShow = computed(() => {
 //音频播放状态
 const audioPlayStatus = reactive({
     isPlaying: false, //是否在播放中
-    playIndex: -1 //在播放的音频消息下标
+    playMsgId: '' //在播放的音频消息id,
 })
 //开始播放
-const startplayAudio = (msgBody, index) => {
+const startplayAudio = (msgBody) => {
     const armRec = new BenzAMRRecorder()
     const src = msgBody.url
-    audioPlayStatus.playIndex = index
+    audioPlayStatus.playMsgId = msgBody.id
     console.log('>>>>>开始播放音频', msgBody.url)
     //初始化音频源并调用播放
     armRec.initWithUrl(src).then(() => {
@@ -92,12 +92,12 @@ const startplayAudio = (msgBody, index) => {
     //播放开始监听
     armRec.onPlay(() => {
         audioPlayStatus.isPlaying = true
-        audioPlayStatus.playIndex = index
+        audioPlayStatus.playMsgId = msgBody.id
     })
     //播放结束监听
     armRec.onStop(() => {
         audioPlayStatus.isPlaying = false
-        audioPlayStatus.playIndex = -1
+        audioPlayStatus.playMsgId = ''
     })
 }
 
@@ -211,7 +211,7 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                                 : 'message_box_content_audio_other'
                         ]"
                         v-if="msgBody.type === ALL_MESSAGE_TYPE.AUDIO"
-                        @click="startplayAudio(msgBody, index)"
+                        @click="startplayAudio(msgBody)"
                         :style="`width:${msgBody.length * 10}px`"
                     >
                         <span class="audio_length_text">
@@ -222,7 +222,7 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                                 isMyself(msgBody)
                                     ? 'play_audio_icon_mine'
                                     : 'play_audio_icon_other',
-                                audioPlayStatus.playIndex === index &&
+                                audioPlayStatus.playMsgId === msgBody.id &&
                                     'start_play_audio'
                             ]"
                             style="background-size: 100% 100%"

--- a/src/views/Chat/components/Message/components/messageList.vue
+++ b/src/views/Chat/components/Message/components/messageList.vue
@@ -8,9 +8,9 @@ import BenzAMRRecorder from 'benz-amr-recorder'
 import fileSizeFormat from '@/utils/fileSizeFormat'
 import dateFormat from '@/utils/dateFormater'
 import { messageType } from '@/constant'
-import {
-    handleSDKErrorNotifi
-} from '@/utils/handleSomeData'
+import { handleSDKErrorNotifi } from '@/utils/handleSomeData'
+/* utils */
+import paseLink from '@/utils/paseLink'
 /* 默认头像 */
 import defaultAvatar from '@/assets/images/avatar/theme2x.png'
 import ReportMessage from './suit/reportMessage.vue'
@@ -20,13 +20,12 @@ const store = useStore()
 const props = defineProps({
     messageData: {
         type: [Array, Object],
-        default: () => [],
+        default: () => []
     },
     nowPickInfo: {
         type: Object,
         default: () => ({})
     }
-
 })
 /* emits */
 const emit = defineEmits(['scrollMessageList', 'reEditMessage'])
@@ -39,7 +38,7 @@ const loginUserId = EaseChatClient.user
 /* computed-- 消息来源是否为自己 */
 const isMyself = computed(() => {
     return (msgBody) => {
-        return (msgBody.from === loginUserId)
+        return msgBody.from === loginUserId
     }
 })
 /* 获取自己的用户信息 */
@@ -48,11 +47,12 @@ const loginUserInfo = computed(() => store.state.loginUserInfo)
 /* 获取他人的用户信息 */
 const otherUserInfo = computed(() => {
     return (otherId) => {
-        const otherInfos = store.state.Contacts.friendList[otherId] || { avatarurl: defaultAvatar }
+        const otherInfos = store.state.Contacts.friendList[otherId] || {
+            avatarurl: defaultAvatar
+        }
         return otherInfos
     }
-}
-)
+})
 
 /* 处理时间显示间隔 */
 
@@ -74,8 +74,8 @@ const handleMsgTimeShow = computed(() => {
 })
 //音频播放状态
 const audioPlayStatus = reactive({
-    isPlaying: false,//是否在播放中
-    playIndex: -1, //在播放的音频消息下标
+    isPlaying: false, //是否在播放中
+    playIndex: -1 //在播放的音频消息下标
 })
 //开始播放
 const startplayAudio = (msgBody, index) => {
@@ -101,7 +101,6 @@ const startplayAudio = (msgBody, index) => {
     })
 }
 
-
 //复制文本
 // const permissionRead = usePermission('clipboard-read') //请求剪切板读的权限
 // const permissionWrite = usePermission('clipboard-write') //请求剪切板写的权限
@@ -112,7 +111,7 @@ const copyTextMessages = (msg) => {
         ElMessage({
             type: 'success',
             message: '成功复制到剪切板',
-            center: true,
+            center: true
         })
         console.log('>>>>>成功复制')
     }
@@ -130,7 +129,6 @@ const recallMessage = async ({ id, to, chatType }) => {
         handleSDKErrorNotifi(error.type, error.message)
         console.log('>>>>>>撤回失败', error)
     }
-
 }
 //删除消息（非从服务器删除）
 const deleteMessage = ({ from, to, id: mid }) => {
@@ -149,101 +147,205 @@ const reEdit = (msg) => emit('reEditMessage', msg)
 </script>
 <template>
     <div>
-        <div class="messageList_box" v-for="(msgBody, index) in messageData" :key="msgBody.id">
-            <div v-if="!msgBody.isRecall && msgBody.type !== ALL_MESSAGE_TYPE.INFORM" class="message_box_item"
-                :style="{ flexDirection: (isMyself(msgBody) ? 'row-reverse' : 'row') }">
-                <div class="message_item_time">{{ handleMsgTimeShow(msgBody.time, index) || '' }}</div>
-                <el-avatar class="message_item_avator"
-                    :src="isMyself(msgBody) ? loginUserInfo.avatarurl : otherUserInfo(msgBody.from).avatarurl || defaultAvatar">
+        <div
+            class="messageList_box"
+            v-for="(msgBody, index) in messageData"
+            :key="msgBody.id"
+        >
+            <div
+                v-if="
+                    !msgBody.isRecall &&
+                    msgBody.type !== ALL_MESSAGE_TYPE.INFORM
+                "
+                class="message_box_item"
+                :style="{
+                    flexDirection: isMyself(msgBody) ? 'row-reverse' : 'row'
+                }"
+            >
+                <div class="message_item_time">
+                    {{ handleMsgTimeShow(msgBody.time, index) || '' }}
+                </div>
+                <el-avatar
+                    class="message_item_avator"
+                    :src="
+                        isMyself(msgBody)
+                            ? loginUserInfo.avatarurl
+                            : otherUserInfo(msgBody.from).avatarurl ||
+                              defaultAvatar
+                    "
+                >
                 </el-avatar>
-                <el-dropdown class="message_box_content"
-                    :class="[isMyself(msgBody) ? 'message_box_content_mine' : 'message_box_content_other']"
-                    trigger="contextmenu" placement="bottom-end">
+                <el-dropdown
+                    class="message_box_content"
+                    :class="[
+                        isMyself(msgBody)
+                            ? 'message_box_content_mine'
+                            : 'message_box_content_other'
+                    ]"
+                    trigger="contextmenu"
+                    placement="bottom-end"
+                >
                     <!-- 文本类型消息 -->
-                    <p style="padding: 10px" v-if="msgBody.type === ALL_MESSAGE_TYPE.TEXT">
-                        {{ msgBody.msg }}
-                    </p>
+                    <p
+                        style="padding: 10px; line-height: 20px"
+                        v-if="msgBody.type === ALL_MESSAGE_TYPE.TEXT"
+                        v-html="paseLink(msgBody.msg)"
+                    ></p>
                     <!-- 图片类型消息 -->
                     <!-- <div> -->
-                    <el-image v-if="msgBody.type === ALL_MESSAGE_TYPE.IMAGE" style="border-radius:5px;"
-                        :src="msgBody.thumb" :preview-src-list="[msgBody.url]" :initial-index="1" fit="cover" />
+                    <el-image
+                        v-if="msgBody.type === ALL_MESSAGE_TYPE.IMAGE"
+                        style="border-radius: 5px"
+                        :src="msgBody.thumb"
+                        :preview-src-list="[msgBody.url]"
+                        :initial-index="1"
+                        fit="cover"
+                    />
                     <!-- </div> -->
                     <!-- 语音类型消息 -->
-                    <div :class="['message_box_content_audio', isMyself(msgBody) ? 'message_box_content_audio_mine' : 'message_box_content_audio_other']"
-                        v-if="msgBody.type === ALL_MESSAGE_TYPE.AUDIO" @click="startplayAudio(msgBody, index)"
-                        :style="`width:${msgBody.length * 10}px`">
+                    <div
+                        :class="[
+                            'message_box_content_audio',
+                            isMyself(msgBody)
+                                ? 'message_box_content_audio_mine'
+                                : 'message_box_content_audio_other'
+                        ]"
+                        v-if="msgBody.type === ALL_MESSAGE_TYPE.AUDIO"
+                        @click="startplayAudio(msgBody, index)"
+                        :style="`width:${msgBody.length * 10}px`"
+                    >
                         <span class="audio_length_text">
                             {{ msgBody.length }}′′
                         </span>
-                        <div :class="[isMyself(msgBody) ? 'play_audio_icon_mine' : 'play_audio_icon_other', audioPlayStatus.playIndex === index && 'start_play_audio']"
-                            style=" background-size: 100% 100%;">
-                        </div>
+                        <div
+                            :class="[
+                                isMyself(msgBody)
+                                    ? 'play_audio_icon_mine'
+                                    : 'play_audio_icon_other',
+                                audioPlayStatus.playIndex === index &&
+                                    'start_play_audio'
+                            ]"
+                            style="background-size: 100% 100%"
+                        ></div>
                     </div>
                     <div v-if="msgBody.type === ALL_MESSAGE_TYPE.LOCAL">
                         <p style="padding: 10px">[暂不支持位置消息展示]</p>
                     </div>
                     <!-- 文件类型消息 -->
-                    <div v-if="msgBody.type === ALL_MESSAGE_TYPE.FILE" class="message_box_content_file">
+                    <div
+                        v-if="msgBody.type === ALL_MESSAGE_TYPE.FILE"
+                        class="message_box_content_file"
+                    >
                         <div class="file_text_box">
                             <div class="file_name">{{ msgBody.filename }}</div>
-                            <div class="file_size">{{ fileSizeFormat(msgBody.file_length) }}</div>
-                            <a class="file_download" :href="msgBody.url" download>点击下载</a>
+                            <div class="file_size">
+                                {{ fileSizeFormat(msgBody.file_length) }}
+                            </div>
+                            <a
+                                class="file_download"
+                                :href="msgBody.url"
+                                download
+                                >点击下载</a
+                            >
                         </div>
                         <span class="iconfont icon-wenjian"></span>
                     </div>
                     <!-- 自定义类型消息 -->
-                    <div v-if="msgBody.type === ALL_MESSAGE_TYPE.CUSTOM" class="message_box_content_custom">
-                        <template v-if="msgBody.customEvent && CUSTOM_TYPE[msgBody.customEvent]">
+                    <div
+                        v-if="msgBody.type === ALL_MESSAGE_TYPE.CUSTOM"
+                        class="message_box_content_custom"
+                    >
+                        <template
+                            v-if="
+                                msgBody.customEvent &&
+                                CUSTOM_TYPE[msgBody.customEvent]
+                            "
+                        >
                             <div class="user_card">
                                 <div class="user_card_main">
                                     <!-- 头像 -->
-                                    <el-avatar shape="circle" :size="50"
-                                        :src="msgBody.customExts && msgBody.customExts.avatarurl || msgBody.customExts.avatar || defaultAvatar"
-                                        fit="cover" />
+                                    <el-avatar
+                                        shape="circle"
+                                        :size="50"
+                                        :src="
+                                            (msgBody.customExts &&
+                                                msgBody.customExts.avatarurl) ||
+                                            msgBody.customExts.avatar ||
+                                            defaultAvatar
+                                        "
+                                        fit="cover"
+                                    />
                                     <!-- 昵称 -->
-                                    <span class="nickname">{{ msgBody.customExts && msgBody.customExts.nickname ||
-                                            msgBody.customExts.uid
+                                    <span class="nickname">{{
+                                        (msgBody.customExts &&
+                                            msgBody.customExts.nickname) ||
+                                        msgBody.customExts.uid
                                     }}</span>
                                 </div>
-                                <el-divider style="margin:5px 0;  border-top:1px solid black;" />
-                                <p style="font-size: 8px;">个人名片</p>
+                                <el-divider
+                                    style="
+                                        margin: 5px 0;
+                                        border-top: 1px solid black;
+                                    "
+                                />
+                                <p style="font-size: 8px">个人名片</p>
                             </div>
                         </template>
                     </div>
                     <template #dropdown>
                         <el-dropdown-menu>
-                            <el-dropdown-item v-if="msgBody.type === ALL_MESSAGE_TYPE.TEXT && isSupported"
-                                @click="copyTextMessages(msgBody.msg)">
+                            <el-dropdown-item
+                                v-if="
+                                    msgBody.type === ALL_MESSAGE_TYPE.TEXT &&
+                                    isSupported
+                                "
+                                @click="copyTextMessages(msgBody.msg)"
+                            >
                                 复制
                             </el-dropdown-item>
-                            <el-dropdown-item v-if="isMyself(msgBody)" @click="recallMessage(msgBody)">
+                            <el-dropdown-item
+                                v-if="isMyself(msgBody)"
+                                @click="recallMessage(msgBody)"
+                            >
                                 撤回
                             </el-dropdown-item>
                             <el-dropdown-item @click="deleteMessage(msgBody)">
                                 删除
                             </el-dropdown-item>
-                            <el-dropdown-item v-if="!isMyself(msgBody)" @click="informOnMessage(msgBody)">
+                            <el-dropdown-item
+                                v-if="!isMyself(msgBody)"
+                                @click="informOnMessage(msgBody)"
+                            >
                                 举报
                             </el-dropdown-item>
                         </el-dropdown-menu>
                     </template>
-
                 </el-dropdown>
             </div>
-            <div v-if="msgBody.isRecall" class="recall_style">{{ isMyself(msgBody) ? "你" : `${msgBody.from}`
-            }}撤回了一条消息<span class="reEdit" v-show="isMyself(msgBody) && msgBody.type === ALL_MESSAGE_TYPE.TEXT"
-                    @click="reEdit(msgBody.msg)">重新编辑</span></div>
-            <div v-if="msgBody.type === ALL_MESSAGE_TYPE.INFORM" class="inform_style">
+            <div v-if="msgBody.isRecall" class="recall_style">
+                {{
+                    isMyself(msgBody) ? '你' : `${msgBody.from}`
+                }}撤回了一条消息<span
+                    class="reEdit"
+                    v-show="
+                        isMyself(msgBody) &&
+                        msgBody.type === ALL_MESSAGE_TYPE.TEXT
+                    "
+                    @click="reEdit(msgBody.msg)"
+                    >重新编辑</span
+                >
+            </div>
+            <div
+                v-if="msgBody.type === ALL_MESSAGE_TYPE.INFORM"
+                class="inform_style"
+            >
                 <p>
                     {{ msgBody.msg }}
                 </p>
             </div>
-
         </div>
         <ReportMessage ref="reportMessage" />
     </div>
-
-
 </template>
 
 <style lang="scss" scoped>
@@ -268,17 +370,15 @@ const reEdit = (msg) => emit('reEditMessage', msg)
             margin: auto;
             width: 74px;
             height: 20px;
-            color: #ADADAD;
+            color: #adadad;
             font-weight: 400;
             font-size: 10px;
             line-height: 20px;
-
         }
 
         .message_item_avator {
             width: 38px;
             height: 38px;
-
         }
 
         .message_box_content {
@@ -312,19 +412,22 @@ const reEdit = (msg) => emit('reEditMessage', msg)
 
                 @keyframes other_play_icon {
                     0% {
-                        background: url('@/assets/images/playAudio/msg_recv_audio02@3x.png') no-repeat;
+                        background: url('@/assets/images/playAudio/msg_recv_audio02@3x.png')
+                            no-repeat;
 
                         background-size: 100% 100%;
                     }
 
                     50% {
-                        background: url('@/assets/images/playAudio/msg_recv_audio01@3x.png') no-repeat;
+                        background: url('@/assets/images/playAudio/msg_recv_audio01@3x.png')
+                            no-repeat;
 
                         background-size: 100% 100%;
                     }
 
                     100% {
-                        background: url('@/assets/images/playAudio/msg_recv_audio@3x.png') no-repeat;
+                        background: url('@/assets/images/playAudio/msg_recv_audio@3x.png')
+                            no-repeat;
                         background-size: 100% 100%;
                     }
                 }
@@ -332,7 +435,8 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                 .play_audio_icon_other {
                     width: 30px;
                     height: 30px;
-                    background: url('@/assets/images/playAudio/msg_recv_audio@3x.png') no-repeat;
+                    background: url('@/assets/images/playAudio/msg_recv_audio@3x.png')
+                        no-repeat;
                     margin-right: 10px;
                 }
 
@@ -348,19 +452,22 @@ const reEdit = (msg) => emit('reEditMessage', msg)
 
                 @keyframes mine_play_icon {
                     0% {
-                        background: url('@/assets/images/playAudio/msg_send_audio02@3x.png') no-repeat;
+                        background: url('@/assets/images/playAudio/msg_send_audio02@3x.png')
+                            no-repeat;
 
                         background-size: 100% 100%;
                     }
 
                     50% {
-                        background: url('@/assets/images/playAudio/msg_send_audio01@3x.png') no-repeat;
+                        background: url('@/assets/images/playAudio/msg_send_audio01@3x.png')
+                            no-repeat;
 
                         background-size: 100% 100%;
                     }
 
                     100% {
-                        background: url('@/assets/images/playAudio/msg_send_audio@3x.png') no-repeat;
+                        background: url('@/assets/images/playAudio/msg_send_audio@3x.png')
+                            no-repeat;
                         background-size: 100% 100%;
                     }
                 }
@@ -369,7 +476,8 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                     width: 30px;
                     height: 30px;
                     background-size: 100% 100%;
-                    background: url('@/assets/images/playAudio/msg_send_audio@3x.png') no-repeat;
+                    background: url('@/assets/images/playAudio/msg_send_audio@3x.png')
+                        no-repeat;
                     margin-left: 10px;
                 }
 
@@ -415,7 +523,7 @@ const reEdit = (msg) => emit('reEditMessage', msg)
                         color: #333333;
                         font-size: 13px;
                         cursor: pointer;
-                        transition: all .3s ease;
+                        transition: all 0.3s ease;
 
                         &:hover {
                             transform: scale(0.9);
@@ -462,15 +570,14 @@ const reEdit = (msg) => emit('reEditMessage', msg)
         }
 
         .message_box_content_other {
-            background: #FFF;
+            background: #fff;
             border-radius: 8px 8px 8px 0px;
         }
 
         .message_box_content_mine {
-            background: #C1E3FC;
+            background: #c1e3fc;
             border-radius: 8px 0px 8px 8px;
         }
-
     }
 
     /* 撤回或者系统通知类消息 */
@@ -483,12 +590,11 @@ const reEdit = (msg) => emit('reEditMessage', msg)
         margin: 5px 0;
 
         .reEdit {
-            color: #3E91FA;
+            color: #3e91fa;
             margin-left: 3px;
             cursor: pointer;
         }
     }
-
 }
 
 :deep(.el-input__wrapper) {
@@ -496,7 +602,7 @@ const reEdit = (msg) => emit('reEditMessage', msg)
 }
 
 :deep(.el-dialog__header) {
-    background: #F2F2F2;
+    background: #f2f2f2;
     margin: 0;
 }
 </style>

--- a/src/views/Chat/components/Message/index.vue
+++ b/src/views/Chat/components/Message/index.vue
@@ -319,7 +319,7 @@ const reEditMessage = (msg) => (inputBox.value.textContent = msg)
                     <div v-show="isMoreHistoryMsg" class="chat_message_tips">
                         <div
                             v-show="
-                                messageData.length > 0 &&
+                                messageData.length?.length &&
                                 messageData[0].type !== 'inform'
                             "
                             class="load_more_msg"

--- a/src/views/Chat/components/Message/index.vue
+++ b/src/views/Chat/components/Message/index.vue
@@ -47,9 +47,7 @@ const randomTips = computed(() => {
 /* warterMark */
 onMounted(() => {
     const chatContainer = document.querySelector('.chat_message_main')
-    setTimeout(() => {
-        waterMark({ container: chatContainer })
-    }, 0)
+    chatContainer && waterMark({ container: chatContainer })
 })
 const closeWarningTips = () => store.commit('CLOSE_WARNING_TIPS')
 /* userInfo */
@@ -65,29 +63,41 @@ const getIdInfo = async ({ id, chatType }) => {
     }
     //类型为群组
     if (chatType === CHAT_TYPE.GROUP) {
-        const goupid = groupList.value[id]?.groupid && groupList.value[id]?.groupid
-        goupid && await store.dispatch('fetchMultiGoupsInfos', goupid)
+        const goupid =
+            groupList.value[id]?.groupid && groupList.value[id]?.groupid
+        goupid && (await store.dispatch('fetchMultiGoupsInfos', goupid))
         if (groupList.value[id]?.groupDetail) {
-            return nowPickInfo.value.groupDetail = groupList.value[id].groupDetail
+            return (nowPickInfo.value.groupDetail =
+                groupList.value[id].groupDetail)
         } else {
             //如果不存在用户属性则请求获取该群群详情。
             await store.dispatch('getAssignGroupDetail', id)
-            return nowPickInfo.value.groupDetail = groupList.value[id].groupDetail
+            return (nowPickInfo.value.groupDetail =
+                groupList.value[id].groupDetail)
         }
     }
 }
 //监听路由改变获取对应的getIdInfo
-const stopWatchRoute = watch(() => route.query, (routeVal) => {
-    console.log('>>>>>>>>监听到路由参数变化', routeVal)
-    if (routeVal) {
-        nowPickInfo.value = { ...routeVal }
-        loginState.value && getIdInfo(routeVal)
+const stopWatchRoute = watch(
+    () => route.query,
+    (routeVal) => {
+        console.log('>>>>>>>>监听到路由参数变化', routeVal)
+        if (routeVal) {
+            nowPickInfo.value = { ...routeVal }
+            loginState.value && getIdInfo(routeVal)
+        }
+    },
+    {
+        immediate: true
     }
-}, {
-    immediate: true
-})
+)
 //获取群组详情
-const groupDetail = computed(() => groupList.value[nowPickInfo.value.id] && groupList.value[nowPickInfo.value.id].groupDetail || {})
+const groupDetail = computed(
+    () =>
+        (groupList.value[nowPickInfo.value.id] &&
+            groupList.value[nowPickInfo.value.id].groupDetail) ||
+        {}
+)
 //离开该路由销毁route监听
 onBeforeRouteLeave(() => {
     stopWatchRoute()
@@ -103,7 +113,10 @@ const fechHistoryMessage = (loadType) => {
         loadingHistoryMsg.value = true
         notScrollBottom.value = true
         if (loadType == 'fistLoad') {
-            const { messages } = await store.dispatch('getHistoryMessage', { ...nowPickInfo.value, cursor: -1 })
+            const { messages } = await store.dispatch('getHistoryMessage', {
+                ...nowPickInfo.value,
+                cursor: -1
+            })
             if (messages.length > 0) {
                 //返回数组有数据显示加载更多
                 isMoreHistoryMsg.value = true
@@ -114,11 +127,13 @@ const fechHistoryMessage = (loadType) => {
             setTimeout(() => {
                 scrollMessageList('bottom')
             }, 500)
-
-        }
-        else {
-            const fistMessageId = messageData.value[0] && messageData.value[0].id
-            const { messages } = await store.dispatch('getHistoryMessage', { ...nowPickInfo.value, cursor: fistMessageId })
+        } else {
+            const fistMessageId =
+                messageData.value[0] && messageData.value[0].id
+            const { messages } = await store.dispatch('getHistoryMessage', {
+                ...nowPickInfo.value,
+                cursor: fistMessageId
+            })
             if (messages.length > 0) {
                 //返回数组有数据显示加载更多
                 isMoreHistoryMsg.value = true
@@ -131,19 +146,22 @@ const fechHistoryMessage = (loadType) => {
         loadingHistoryMsg.value = false
         notScrollBottom.value = false
     }
-
 }
 //获取其id对应的消息内容
 const messageData = computed(() => {
     //如果Message.messageList中不存在的话调用拉取漫游取一下历史消息
-    return nowPickInfo.value.id && store.state.Message.messageList[nowPickInfo.value.id] || fechHistoryMessage('fistLoad')()
+    return (
+        (nowPickInfo.value.id &&
+            store.state.Message.messageList[nowPickInfo.value.id]) ||
+        fechHistoryMessage('fistLoad')()
+    )
 })
 
 const messageContainer = ref(null)
 //控制消息滚动
 const scrollMessageList = (direction) => {
     console.log('>>>>>scrollMessageList', direction)
-    //direction滚动方向 bottom向下滚动 normal向上滚动 
+    //direction滚动方向 bottom向下滚动 normal向上滚动
     nextTick(() => {
         const messageNodeList = document.querySelectorAll('.messageList_box')
         const fistMsgElement = messageNodeList[0]
@@ -162,134 +180,189 @@ const scrollMessageList = (direction) => {
 // const scroll = ({ scrollTop }) => {
 //   console.log('scrollscrollscroll', scrollTop)
 // }
-watch(() => messageData, (newMsg, oldMsg) => {
-    nextTick(() => {
-        console.log('>>>>>监听到消息变化', notScrollBottom.value)
-        //判断拉取漫游导致的消息变化不需要执行滚动置底
-        if (notScrollBottom.value) {
-            return
-        } else {
-            setTimeout(() => {
-                scrollMessageList('bottom')
-            }, 300)
-
-        }
-    })
-}, {
-    deep: true,
-    immediate: true
-})
-//监听到nowPickInfo改变 让消息直接置底
-watch(() => route.query, () => {
-    if (Object.keys(nowPickInfo.value).length > 0) {
+watch(
+    () => messageData,
+    (newMsg, oldMsg) => {
         nextTick(() => {
-            scrollMessageList('bottom')
+            console.log('>>>>>监听到消息变化', notScrollBottom.value)
+            //判断拉取漫游导致的消息变化不需要执行滚动置底
+            if (notScrollBottom.value) {
+                return
+            } else {
+                setTimeout(() => {
+                    scrollMessageList('bottom')
+                }, 300)
+            }
         })
+    },
+    {
+        deep: true,
+        immediate: true
     }
-})
+)
+//监听到nowPickInfo改变 让消息直接置底
+watch(
+    () => route.query,
+    () => {
+        if (Object.keys(nowPickInfo.value).length > 0) {
+            nextTick(() => {
+                scrollMessageList('bottom')
+            })
+        }
+    }
+)
 
 //消息重新编辑
 const inputBox = ref(null)
-const reEditMessage = (msg) => inputBox.value.textContent = msg
-
-
+const reEditMessage = (msg) => (inputBox.value.textContent = msg)
 </script>
 <template>
-  <el-container v-if="loginState" class="app_container">
-    <el-header class="chat_message_header">
-      <template v-if="nowPickInfo.chatType === CHAT_TYPE.SINGLE">
-        <div v-if="nowPickInfo.userInfo" class="chat_user_box">
-          <span class="chat_user_name"> {{ nowPickInfo.userInfo.nickname || nowPickInfo.id }}</span>
-          <UserStatus :userStatus="nowPickInfo.userInfo.userStatus" />
-        </div>
-        <div v-else>{{ nowPickInfo.id }}<span style="font-size:10px">(非好友)</span></div>
-      </template>
-      <template v-if="nowPickInfo.chatType === CHAT_TYPE.GROUP">
-        <div v-if="nowPickInfo.groupDetail" class="chat_user_box">
-          <span class="chat_user_name">
-            {{ groupDetail.name || '' }} {{ `(${groupDetail.affiliations_count || ''})`
-            }}
-          </span>
-
-        </div>
-        <div v-else class="chat_user_box">
-          <span class="chat_user_name">
-            {{ groupDetail.name || nowPickInfo.id }}
-          </span>
-
-        </div>
-      </template>
-      <!-- 群组展示抽屉 -->
-      <span class="more" v-if="nowPickInfo.groupDetail && nowPickInfo.chatType === CHAT_TYPE.GROUP"
-        @click="drawer = !drawer">
-        <svg width="18" height="4" viewBox="0 0 18 4" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="2" cy="2" r="2" fill="#333333" />
-          <circle cx="9" cy="2" r="2" fill="#333333" />
-          <circle cx="16" cy="2" r="2" fill="#333333" />
-        </svg>
-      </span>
-      <!-- 单人展示删除拉黑 -->
-      <span class="more" v-else>
-        <el-dropdown placement="bottom-end" trigger="click">
-          <svg width="18" height="4" viewBox="0 0 18 4" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="2" cy="2" r="2" fill="#333333" />
-            <circle cx="9" cy="2" r="2" fill="#333333" />
-            <circle cx="16" cy="2" r="2" fill="#333333" />
-          </svg>
-          <template #dropdown>
-            <el-dropdown-menu>
-              <el-dropdown-item @click="delTheFriend">
-                删除好友
-              </el-dropdown-item>
-              <!-- <el-dropdown-item @click="addFriendToBlackList">
+    <el-container v-if="loginState" class="app_container">
+        <el-header class="chat_message_header">
+            <template v-if="nowPickInfo.chatType === CHAT_TYPE.SINGLE">
+                <div v-if="nowPickInfo.userInfo" class="chat_user_box">
+                    <span class="chat_user_name">
+                        {{
+                            nowPickInfo.userInfo.nickname || nowPickInfo.id
+                        }}</span
+                    >
+                    <UserStatus :userStatus="nowPickInfo.userInfo.userStatus" />
+                </div>
+                <div v-else>
+                    {{ nowPickInfo.id
+                    }}<span style="font-size: 10px">(非好友)</span>
+                </div>
+            </template>
+            <template v-if="nowPickInfo.chatType === CHAT_TYPE.GROUP">
+                <div v-if="nowPickInfo.groupDetail" class="chat_user_box">
+                    <span class="chat_user_name">
+                        {{ groupDetail.name || '' }}
+                        {{ `(${groupDetail.affiliations_count || ''})` }}
+                    </span>
+                </div>
+                <div v-else class="chat_user_box">
+                    <span class="chat_user_name">
+                        {{ groupDetail.name || nowPickInfo.id }}
+                    </span>
+                </div>
+            </template>
+            <!-- 群组展示抽屉 -->
+            <span
+                class="more"
+                v-if="
+                    nowPickInfo.groupDetail &&
+                    nowPickInfo.chatType === CHAT_TYPE.GROUP
+                "
+                @click="drawer = !drawer"
+            >
+                <svg
+                    width="18"
+                    height="4"
+                    viewBox="0 0 18 4"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <circle cx="2" cy="2" r="2" fill="#333333" />
+                    <circle cx="9" cy="2" r="2" fill="#333333" />
+                    <circle cx="16" cy="2" r="2" fill="#333333" />
+                </svg>
+            </span>
+            <!-- 单人展示删除拉黑 -->
+            <span class="more" v-else>
+                <el-dropdown placement="bottom-end" trigger="click">
+                    <svg
+                        width="18"
+                        height="4"
+                        viewBox="0 0 18 4"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <circle cx="2" cy="2" r="2" fill="#333333" />
+                        <circle cx="9" cy="2" r="2" fill="#333333" />
+                        <circle cx="16" cy="2" r="2" fill="#333333" />
+                    </svg>
+                    <template #dropdown>
+                        <el-dropdown-menu>
+                            <el-dropdown-item @click="delTheFriend">
+                                删除好友
+                            </el-dropdown-item>
+                            <!-- <el-dropdown-item @click="addFriendToBlackList">
                 加入黑名单
               </el-dropdown-item> -->
-            </el-dropdown-menu>
-          </template>
-        </el-dropdown>
-
-      </span>
-    </el-header>
-    <div v-if="isShowWarningTips" class="easeim_safe_tips">
-      <p>{{ EASEIM_HINT }}</p>
-      <p>【防骗提示】{{ randomTips }}</p>
-      <p v-show="nowPickInfo.chatType === CHAT_TYPE.GROUP && nowPickInfo?.groupDetail?.custom !=='default'" >{{ WARM_TIP }}</p>
-      <span class="easeim_close_tips" @click="closeWarningTips">
-        <el-icon>
-          <Close />
-        </el-icon>
-      </span>
-
-    </div>
-    <el-main class="chat_message_main">
-      <el-scrollbar class="main_container" ref="messageContainer">
-        <div class="innerRef">
-          <div v-show="isMoreHistoryMsg" class="chat_message_tips">
-            <div v-show="messageData.length > 0 && messageData[0].type !== 'inform'" class="load_more_msg">
-              <el-link v-show="!loadingHistoryMsg" :disabled="!isMoreHistoryMsg" :underline="false"
-                @click="fechHistoryMessage()()">
-                加载更多
-              </el-link>
-              <el-link v-show="loadingHistoryMsg" disabled>消息加载中...</el-link>
-            </div>
-          </div>
-          <MessageList :messageData="messageData" @scrollMessageList="scrollMessageList"
-            @reEditMessage="reEditMessage" />
+                        </el-dropdown-menu>
+                    </template>
+                </el-dropdown>
+            </span>
+        </el-header>
+        <div v-if="isShowWarningTips" class="easeim_safe_tips">
+            <p>{{ EASEIM_HINT }}</p>
+            <p>【防骗提示】{{ randomTips }}</p>
+            <p
+                v-show="
+                    nowPickInfo.chatType === CHAT_TYPE.GROUP &&
+                    nowPickInfo?.groupDetail?.custom !== 'default'
+                "
+            >
+                {{ WARM_TIP }}
+            </p>
+            <span class="easeim_close_tips" @click="closeWarningTips">
+                <el-icon>
+                    <Close />
+                </el-icon>
+            </span>
         </div>
-      </el-scrollbar>
-    </el-main>
-    <el-footer class="chat_message_inputbar">
-      <InputBox ref="inputBox" :nowPickInfo="nowPickInfo" />
-    </el-footer>
-    <el-drawer v-if="nowPickInfo.chatType === CHAT_TYPE.GROUP" v-model="drawer" :show-close="false"
-      :close-on-click-modal="true" direction="rtl" :modal="true" size="280px">
-      <GroupsDetails :nowGroupId="nowPickInfo.id" :groupDetail="groupDetail" />
-    </el-drawer>
-  </el-container>
+        <el-main class="chat_message_main">
+            <el-scrollbar class="main_container" ref="messageContainer">
+                <div class="innerRef">
+                    <div v-show="isMoreHistoryMsg" class="chat_message_tips">
+                        <div
+                            v-show="
+                                messageData.length > 0 &&
+                                messageData[0].type !== 'inform'
+                            "
+                            class="load_more_msg"
+                        >
+                            <el-link
+                                v-show="!loadingHistoryMsg"
+                                :disabled="!isMoreHistoryMsg"
+                                :underline="false"
+                                @click="fechHistoryMessage()()"
+                            >
+                                加载更多
+                            </el-link>
+                            <el-link v-show="loadingHistoryMsg" disabled
+                                >消息加载中...</el-link
+                            >
+                        </div>
+                    </div>
+                    <MessageList
+                        :messageData="messageData"
+                        @scrollMessageList="scrollMessageList"
+                        @reEditMessage="reEditMessage"
+                    />
+                </div>
+            </el-scrollbar>
+        </el-main>
+        <el-footer class="chat_message_inputbar">
+            <InputBox ref="inputBox" :nowPickInfo="nowPickInfo" />
+        </el-footer>
+        <el-drawer
+            v-if="nowPickInfo.chatType === CHAT_TYPE.GROUP"
+            v-model="drawer"
+            :show-close="false"
+            :close-on-click-modal="true"
+            direction="rtl"
+            :modal="true"
+            size="280px"
+        >
+            <GroupsDetails
+                :nowGroupId="nowPickInfo.id"
+                :groupDetail="groupDetail"
+            />
+        </el-drawer>
+    </el-container>
 </template>
 
-
-
 <style lang="scss" scoped>
-@import "./index.scss"
+@import './index.scss';
 </style>

--- a/src/views/Chat/components/Message/index.vue
+++ b/src/views/Chat/components/Message/index.vue
@@ -319,7 +319,7 @@ const reEditMessage = (msg) => (inputBox.value.textContent = msg)
                     <div v-show="isMoreHistoryMsg" class="chat_message_tips">
                         <div
                             v-show="
-                                messageData.length?.length &&
+                                messageData?.length &&
                                 messageData[0].type !== 'inform'
                             "
                             class="load_more_msg"

--- a/src/views/Chat/components/Message/index.vue
+++ b/src/views/Chat/components/Message/index.vue
@@ -150,11 +150,13 @@ const fechHistoryMessage = (loadType) => {
 //获取其id对应的消息内容
 const messageData = computed(() => {
     //如果Message.messageList中不存在的话调用拉取漫游取一下历史消息
-    return (
-        (nowPickInfo.value.id &&
-            store.state.Message.messageList[nowPickInfo.value.id]) ||
-        fechHistoryMessage('fistLoad')()
-    )
+    if (loginState.value) {
+        return (
+            (nowPickInfo.value.id &&
+                store.state.Message.messageList[nowPickInfo.value.id]) ||
+            fechHistoryMessage('fistLoad')()
+        )
+    }
 })
 
 const messageContainer = ref(null)


### PR DESCRIPTION
此PR分别修复了四个问题，一个新增。
1）waterMarkquerySellecter of undefined，修复该问题在刷新页面时浏览器出现，Cannot read properties of null (reading 'querySelector') 的问题。
2）fix:page unReady fetch history message error，修复该问题在某会话已有消息的情况下，拉取漫游消息出现会话未读数统计异常问题。
3）length of undefined 修复在聊天页面无消息时，聊天页面判断加载更多展示出现，length of undefined 问题。
4）增加对url的识别匹配为，文本消息如包含有url地址则自动增加a标签，供点击跳转。